### PR TITLE
Remove need for admin rights for configuration

### DIFF
--- a/cli/constants.py
+++ b/cli/constants.py
@@ -2,4 +2,4 @@ import os
 from pathlib import Path
 
 
-CONFIGURATION_FILE = os.path.join(Path.home(), "twitch-clip-manager.json")
+CONFIGURATION_FILE = os.path.join(Path.home(), ".tcmanger", "config.json")

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -3,18 +3,8 @@ import ctypes
 import sys
 from termcolor import colored
 from cli.constants import CONFIGURATION_FILE
-
-
-def _is_admin():
-    if sys.platform == "win32":
-        try:
-            return ctypes.windll.shell32.IsUserAdmin()
-        except:
-            return False
-    elif sys.platform == "linux":
-        return os.geteuid() == 0
-    else:
-        raise Exception(f"Unsupported platform: {sys.platform}")
+from pathlib import Path
+import json
 
 
 def _configuration_file_exists():
@@ -26,16 +16,15 @@ def _configuration_file_exists():
 
 
 def _create_configuration_file(configuration, downloads_directory):
-    if _is_admin():
-        with open(CONFIGURATION_FILE, "w") as config:
-            config_data = {
-                "client_id": configuration["client_id"],
-                "client_secret": configuration["client_secret"],
-                "username": configuration["username"],
-                "downloads_directory": downloads_directory,
-            }
-            config.write(config_data)
-            return True
-    else:
-        print(colored("Please launch this application as admin to configure.", "red"))
-        return False
+    config_path = Path(CONFIGURATION_FILE)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(CONFIGURATION_FILE, "w+") as config:
+        config_data = {
+            "client_id": configuration["client_id"],
+            "client_secret": configuration["client_secret"],
+            "username": configuration["username"],
+            "downloads_directory": downloads_directory,
+        }
+        config.write(json.dumps(config_data))
+        return True

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from cli.styles import twitch_theme
 import tkinter as tk
 from tkinter import filedialog
 from termcolor import colored
-from cli.utils import _create_configuration_file, _configuration_file_exists, _is_admin
+from cli.utils import _create_configuration_file, _configuration_file_exists
 from cli.downloader import Downloader
 import sys
 import os
@@ -77,10 +77,6 @@ configure_options = [
 main_menu = prompt(main_menu_options, style=twitch_theme)
 
 if main_menu["main"] == "Configure":
-    if not _is_admin():
-        print(colored("Please launch this application as admin to configure.", "red",))
-        sys.exit()
-
     if _configuration_file_exists():
         overwrite = _ask_for_confirmation(
             "Configuration already exists. Overwrite existing?"


### PR DESCRIPTION
Remove unnecessary need for admin rights to create configuration file.

BREAK CHANGES:
- Configuration is now located at `~/.tcmanger/config.json` rather than `~/twitch-config-manager.json`.